### PR TITLE
Fix code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
 
 matrix:
   exclude:
-    - compiler: gcc
-      env: COVERAGE="ENABLE_COVERAGE=ON"
 
 before_install:
       - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
@@ -57,4 +55,5 @@ script:
   - if [ ${COVERAGE} == "ENABLE_COVERAGE=ON" ] ; then make gcov ; fi
 
 after_success:
+  - cd ${TRAVIS_BUILD_DIR}
   - if [ ${COVERAGE} == "ENABLE_COVERAGE=ON" ] ; then bash <(curl -s https://codecov.io/bash) ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,12 @@ install:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir dependencies
   - cd dependencies
-  - wget https://github.com/Snaipe/Criterion/releases/download/v2.2.2/criterion-v2.2.2-linux-x86_64.tar.bz2 -O criterion.tar.bz2
+  - wget https://github.com/Snaipe/Criterion/releases/download/v2.3.0/criterion-v2.3.0-linux-x86_64.tar.bz2 -O criterion.tar.bz2
   - tar xvjf criterion.tar.bz2
-  - mv criterion-v2.2.2/* .
-  - sudo mv lib/libcriterion.so /usr/local/lib/libcriterion.so
+  - mv criterion-v2.3.0/* .
+  - sudo cp lib/libcriterion.so /usr/local/lib/libcriterion.so
+  - sudo cp lib/libcriterion.so.3 /usr/local/lib/libcriterion.so.3
+  - sudo cp lib/libcriterion.so.3.1.0 /usr/local/lib/libcriterion.so.3.1.0
   - sudo ldconfig
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,7 @@ include_directories(include)
 
 add_library(elegan-c
     include/elegan-c/safe_memory.h
-    include/elegan-c/safe_string.h
     src/safe_memory.c
-    src/safe_string.c
 )
 
 add_coverage(elegan-c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ add_library(elegan-c
 
 add_coverage(elegan-c)
 
+# Evaluate coverage here, so only the code of the main library is included in
+# the coverage report
+coverage_evaluate()
+
 
 # ======================== Enable testing if possible ========================
 set(dependencies_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/include)
@@ -65,6 +69,3 @@ if(CRITERION)
 else(CRITERION)
     message(STATUS "Criterion - not found")
 endif()
-
-# ============================= Evaluate coverage ============================
-coverage_evaluate()

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Linux build status](https://img.shields.io/travis/VanJanssen/elegan-c/master.svg?label=Linux)](https://travis-ci.org/VanJanssen/elegan-c)
 [![Windows Build Status](https://img.shields.io/appveyor/ci/ErwinJanssen/elegan-c/master.svg?label=Windows)](https://ci.appveyor.com/project/ErwinJanssen/elegan-c/branch/master)
 [![Coverity Scan](https://img.shields.io/coverity/scan/10836.svg?label=Coverity)](https://scan.coverity.com/projects/vanjanssen-elegan-c)
+[![Coverage Status](https://img.shields.io/codecov/c/github/VanJanssen/elegan-c/master.svg)](https://codecov.io/github/VanJanssen/elegan-c?branch=master)
 
 Elegan-C (pronounced "elegancy") is a C library that helps you write code that
 is simpler, less verbose and generally more elegant. It does this by providing

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,10 @@ function(add_unit_test test_name)
     add_executable(${test_name} ${test_name}.c)
     target_link_libraries(${test_name} elegan-c criterion)
     add_test(${test_name} ${test_name})
+
+    # The target is also added to the coverage, but this is only for
+    # linkage when coverage is enabled. The code for the test is not
+    # included in the coverage report.
     add_coverage(${test_name})
 endfunction(add_unit_test)
 


### PR DESCRIPTION
Code coverage wasn't generated properly. This was mostly the caused by an empty source file being included in the build and using an older version of Criterion.